### PR TITLE
refactor: improve JSON loading logging and type hints

### DIFF
--- a/docs/code_improvement_log/2025-09-11-consistent-json-error-logging.md
+++ b/docs/code_improvement_log/2025-09-11-consistent-json-error-logging.md
@@ -1,0 +1,20 @@
+# Code Improvement Log - 2025-09-11
+
+## Improvement: Consistent JSON Error Logging and Type Hints
+
+**Files Modified:** `src/disaster_classifier/utils/io.py`
+
+**Change Type:** Error Handling & Maintainability
+
+**Description:**
+- Replaced `print` statements with structured logging in `load_json`
+- Added type hints across all utility functions in `io.py`
+- Added error handling for general `OSError` cases during file reads
+
+**Impact:**
+- Improves observability by routing failures through the application's logging system
+- Enhances code readability and static analysis through explicit type hints
+- Prevents silent failures and aids debugging when JSON loading issues occur
+
+**Validation:**
+- `pytest -q`

--- a/src/disaster_classifier/utils/io.py
+++ b/src/disaster_classifier/utils/io.py
@@ -1,46 +1,49 @@
-"""
-Input/output utility functions for loading and saving configuration files.
-"""
+"""Input/output utility functions for loading and saving configuration files."""
 
+from typing import Any, Dict, Optional
 import json
 import logging
 
+logger = logging.getLogger(__name__)
 
-def load_json(file_path):
-    """
-    Load a JSON file and return its contents as a dictionary.
 
-    This function opens a JSON file, decodes it into a Python object, and returns that object. 
-    If the file does not exist, cannot be opened, or does not contain a valid JSON object, 
-    an error message is printed and the function returns None. 
-    If the JSON object is not a dictionary, an error message is printed and the function returns None.
+def load_json(file_path: str) -> Optional[Dict[str, Any]]:
+    """Load a JSON file and return its contents as a dictionary.
+
+    This function opens a JSON file, decodes it into a Python object, and returns that object.
+    If the file does not exist, cannot be opened, or does not contain a valid JSON object,
+    an error is logged and the function returns ``None``. If the JSON object is not a dictionary,
+    an error is logged and the function returns ``None``.
 
     Args:
-    file_path (str): The file path of the JSON file.
+        file_path: The file path of the JSON file.
 
     Returns:
-    data (dict): The contents of the JSON file as a dictionary, or None if an error occurred.
+        The contents of the JSON file as a dictionary, or ``None`` if an error occurred.
     """
     try:
         with open(file_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+            data: Any = json.load(f)
     except FileNotFoundError:
-        print(f"File not found: {file_path}")
+        logger.error("File not found: %s", file_path)
         return None
-    except json.JSONDecodeError:
-        print(f"Error decoding JSON from file: {file_path}")
+    except json.JSONDecodeError as exc:
+        logger.error("Error decoding JSON from %s: %s", file_path, exc)
+        return None
+    except OSError as exc:
+        logger.error("Error reading %s: %s", file_path, exc)
         return None
 
     if not isinstance(data, dict):
-        print(
-            f"Expected a dictionary in file: {file_path}, but got {type(data)} instead."
+        logger.error(
+            "Expected a dictionary in file: %s, but got %s", file_path, type(data)
         )
         return None
 
     return data
 
 
-def load_model_parameters(file_path):
+def load_model_parameters(file_path: str) -> Optional[Dict[str, Any]]:
     """
     Load a JSON file and return its contents as a dictionary with parameter processing.
 
@@ -79,7 +82,7 @@ def load_model_parameters(file_path):
     return parameters
 
 
-def load_hyperparameter_optimization_config(file_path):
+def load_hyperparameter_optimization_config(file_path: str) -> Optional[Dict[str, Any]]:
     """
     Load a JSON file and return its contents as a dictionary with hyperparameter optimization configuration.
 
@@ -108,17 +111,16 @@ def load_hyperparameter_optimization_config(file_path):
     return parameters
 
 
-def save_json(data, file_path):
-    """
-    Save data to a JSON file.
+def save_json(data: Any, file_path: str) -> None:
+    """Save data to a JSON file.
 
     Args:
-    data: The data to save (must be JSON serializable)
-    file_path (str): The file path where the JSON file should be saved.
+        data: The data to save (must be JSON serializable).
+        file_path: The file path where the JSON file should be saved.
     """
     try:
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
-    except Exception as e:
-        logging.error(f"Error saving JSON to {file_path}: {e}")
+    except Exception as exc:  # pragma: no cover - basic error propagation
+        logger.error("Error saving JSON to %s: %s", file_path, exc)
         raise


### PR DESCRIPTION
## Summary
- add structured logging and type hints to JSON I/O utilities
- log errors instead of printing for JSON loading
- document improvement in code improvement log

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils'; No module named 'train_classifier')*

------
https://chatgpt.com/codex/tasks/task_e_68c2dfdeef6883318e66d28a80532e1e