### PR TITLE
style: polish UI with dark theme components

### DIFF
--- a/app/static/css/tailwind.css
+++ b/app/static/css/tailwind.css
@@ -1,5 +1,31 @@
 /* Tailwind CSS - Custom build for Signal Storm Flask App */
 
+/* Custom theme tokens */
+:root {
+  --brand-accent: #3182CE;
+  --bg: #1A202C;
+  --card: #2D3748;
+  --text: rgb(229,231,235);
+  --muted: rgb(156,163,175);
+}
+
+@layer base {
+  body {@apply bg-[var(--bg)] text-[var(--text)];}
+  h1 {@apply text-4xl md:text-5xl font-extrabold;}
+  h2 {@apply text-3xl font-bold;}
+  h3 {@apply text-xl font-semibold;}
+  p,li {@apply text-base;}
+  a,button {@apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--brand-accent)];}
+}
+
+@layer components {
+  .container-page {@apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;}
+  .btn-primary {@apply inline-flex items-center rounded-xl px-4 py-2 font-semibold bg-[var(--brand-accent)] text-white hover:bg-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400;}
+  .card {@apply rounded-2xl bg-[var(--card)] ring-1 ring-black/10 p-6;}
+  .badge-accent {@apply rounded-full px-3 py-1 text-sm bg-[#3182CE]/20 text-blue-200 ring-1 ring-[#3182CE]/40;}
+  .caption {@apply text-sm text-[var(--muted)];}
+}
+
 /* Base styles */
 *, ::before, ::after {
   --tw-border-spacing-x: 0;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,48 +48,48 @@
     <script src="https://cdn.plot.ly/plotly-2.32.0.min.js" charset="utf-8"></script>
 </head>
 
-<body class="bg-brand-charcoal text-gray-200 font-sans">
-    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-brand-accent-blue text-white px-3 py-2 rounded">Skip to content</a>
+<body>
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 bg-[var(--brand-accent)] text-white px-3 py-2 rounded">Skip to content</a>
 
 <!-- Navigation Bar -->
-<nav class="bg-brand-slate shadow-md sticky top-0 z-50">
-    <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-        <a class="text-2xl font-bold text-white hover:text-brand-accent-blue focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}">
+<nav class="sticky top-0 z-50 backdrop-blur bg-slate-900/70 ring-1 ring-black/10">
+    <div class="container-page py-4 flex justify-between items-center">
+        <a class="text-2xl font-bold text-white" href="/">
             Signal Storm <span role="img" aria-label="Tornado">🌪️</span>
         </a>
         <!-- Mobile Menu Button -->
         <div class="md:hidden">
-            <button id="mobile-menu-button" class="text-white rounded-md p-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue">
+            <button id="mobile-menu-button" class="text-white rounded-md p-1">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
             </button>
         </div>
         <!-- Desktop Menu -->
         <div class="hidden md:flex space-x-4">
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#hero">Home</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#classifier">Try It</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#data">Data</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#how-it-works">How It Works</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#performance">Performance</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="https://www.linkedin.com/in/grantgeist/" target="_blank" rel="noopener noreferrer">Contact</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="https://github.com/geista" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#hero">Home</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#classifier">Try It</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#data">Data</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#how-it-works">How It Works</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#performance">Performance</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="https://www.linkedin.com/in/grantgeist/" target="_blank" rel="noopener noreferrer">Contact</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="https://github.com/geista" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
     </div>
     <!-- Mobile Menu -->
-    <div id="mobile-menu" class="hidden bg-brand-slate px-6 py-4 border-t border-gray-700">
+    <div id="mobile-menu" class="hidden px-6 py-4 border-t border-gray-700 bg-slate-900/70 backdrop-blur">
         <div class="flex flex-col space-y-2">
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#hero">Home</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#classifier">Try It</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#data">Data</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#how-it-works">How It Works</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="{{ url_for('index') }}#performance">Performance</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="https://www.linkedin.com/in/grantgeist/" target="_blank" rel="noopener noreferrer">Contact</a>
-            <a class="text-gray-300 hover:text-white rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue" href="https://github.com/ghgeist/disaster_response_project" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#hero">Home</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#classifier">Try It</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#data">Data</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#how-it-works">How It Works</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="/#performance">Performance</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="https://www.linkedin.com/in/grantgeist/" target="_blank" rel="noopener noreferrer">Contact</a>
+            <a class="px-3 py-2 text-gray-300 hover:text-white" href="https://github.com/ghgeist/disaster_response_project" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
     </div>
 </nav>
 
 <!-- Main Content Area -->
-<main id="main-content" class="container mx-auto px-6 py-8">
+<main id="main-content" class="container-page py-8">
 
     <!-- Flash Messages -->
     {% from 'macros/forms.html' import render_flash_messages %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -4,86 +4,81 @@
 
 {% block content %}
     <!-- Hero Section -->
-    <div id="hero" class="text-center mb-12">
-        <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold text-white mb-3">
-            Signal Storm: Emergency Message Intelligence
-        </h1>
-        <p class="text-lg text-gray-300 max-w-3xl mx-auto">
-            Classify disaster messages instantly
-        </p>
-    </div>
+    <section id="hero" class="container-page text-center mb-12">
+        <h1>Signal Storm: Emergency Message Intelligence</h1>
+        <p class="max-w-3xl mx-auto">Classify disaster messages instantly</p>
+        <a href="#classifier" class="btn-primary mt-6 inline-block">Try the classifier</a>
+    </section>
 
     <!-- Classifier Input Form -->
-    <div id="classifier" class="max-w-3xl mx-auto mb-12">
+    <section id="classifier" class="container-page max-w-3xl mx-auto mb-12">
         {% from 'macros/forms.html' import render_field, render_submit_button %}
         <form action="/go" method="post" class="w-full">
             {{ form.hidden_tag() }}
-            <div class="bg-brand-slate p-6 rounded-lg shadow-lg">
+            <div class="card">
                 {{ render_field(form.query, help_text="Enter a message about a disaster or emergency situation. The AI will analyze and categorize it for first responders.") }}
                 <div class="flex justify-end">
                     {{ render_submit_button(form.submit) }}
                 </div>
             </div>
         </form>
-    </div>
+    </section>
 
-    <div id="data" class="container mx-auto">
+    <section id="data" class="container-page">
         <!-- Main content block for visualizations -->
         <div class="text-center my-8 border-t border-gray-700 pt-8">
-            <h2 class="text-3xl font-bold text-white">Understanding the Data Landscape</h2>
+            <h2>Understanding the Data Landscape</h2>
         </div>
 
         <!-- Container for Plotly charts (first two charts only) -->
         {% if ids is defined %}
         <div class="grid grid-cols-1 gap-8">
             {% for id in ids[:2] %}
-                <div id="{{id}}" class="bg-brand-slate p-4 rounded-lg shadow-lg" style="width: 100%; max-width: 100%; height: 400px; max-height: 500px;"></div>
+                <div id="{{id}}" class="card" style="width: 100%; max-width: 100%; height: 400px; max-height: 500px;"></div>
                 {% if descriptions %}
-                <p class="text-sm text-gray-400 text-center max-w-2xl mx-auto -mt-2">
+                <p class="caption mt-2 text-center max-w-2xl mx-auto">
                     {{ descriptions[loop.index0] if loop.index0 < descriptions|length else '' }}
                 </p>
                 {% endif %}
             {% endfor %}
         </div>
         {% endif %}
-    </div>
+    </section>
 
     <!-- How It Works Section -->
-    <section id="how-it-works" class="bg-brand-slate mt-16 py-12 rounded-lg">
-        <div class="container mx-auto px-6 text-center">
-            <h2 class="text-3xl font-bold text-white mb-8">How It Works</h2>
+    <section id="how-it-works" class="container-page mt-16">
+        <div class="bg-brand-slate py-12 rounded-lg text-center">
+            <h2 class="mb-8">How It Works</h2>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div class="bg-brand-charcoal p-8 rounded-lg shadow-lg border border-gray-700 hover:border-brand-accent-blue transition-all duration-300">
-                    <h3 class="text-xl font-bold mb-4 text-brand-accent-blue">Data Cleaning</h3>
-                    <p class="text-gray-300 leading-relaxed">Merge messages and categories, remove ambiguities and duplicates, and load into a database for a solid training set.</p>
+                    <h3 class="mb-4 text-brand-accent-blue">Data Cleaning</h3>
+                    <p class="leading-relaxed text-gray-300">Merge messages and categories, remove ambiguities and duplicates, and load into a database for a solid training set.</p>
                 </div>
                 <div class="bg-brand-charcoal p-8 rounded-lg shadow-lg border border-gray-700 hover:border-brand-accent-blue transition-all duration-300">
-                    <h3 class="text-xl font-bold mb-4 text-brand-accent-blue">Feature Extraction (TF-IDF)</h3>
-                    <p class="text-gray-300 leading-relaxed">Custom tokenizer normalizes text and TF-IDF emphasizes critical words while downweighting common terms.</p>
+                    <h3 class="mb-4 text-brand-accent-blue">Feature Extraction (TF-IDF)</h3>
+                    <p class="leading-relaxed text-gray-300">Custom tokenizer normalizes text and TF-IDF emphasizes critical words while downweighting common terms.</p>
                 </div>
                 <div class="bg-brand-charcoal p-8 rounded-lg shadow-lg border border-gray-700 hover:border-brand-accent-blue transition-all duration-300">
-                    <h3 class="text-xl font-bold mb-4 text-brand-accent-blue">Multi-Label Model</h3>
-                    <p class="text-gray-300 leading-relaxed">A MultiOutput Random Forest tags each message with all relevant categories across 36 disaster needs.</p>
+                    <h3 class="mb-4 text-brand-accent-blue">Multi-Label Model</h3>
+                    <p class="leading-relaxed text-gray-300">A MultiOutput Random Forest tags each message with all relevant categories across 36 disaster needs.</p>
                 </div>
             </div>
         </div>
         <!-- Performance Deep Dive with embedded chart -->
-        <div id="performance" class="container mx-auto px-6 text-center mt-12">
-            <h2 class="text-2xl font-bold text-white mb-4">Model Performance Deep Dive</h2>
-            <p class="text-sm text-gray-300 max-w-xl mx-auto mb-6">
+        <div id="performance" class="text-center mt-12">
+            <h2 class="mb-4 text-2xl font-bold text-white">Model Performance Deep Dive</h2>
+            <p class="caption max-w-xl mx-auto mb-6">
                 Baseline vs Optimized: precision improves slightly, but recall drops. In disasters, missing real help messages is costly.
             </p>
-            
+
             <!-- Performance chart container -->
             {% if ids|length > 2 %}
             <div class="max-w-4xl mx-auto">
-                <div id="{{ids[2]}}" class="bg-brand-charcoal p-4 rounded-lg shadow-lg mx-auto" style="width: 100%; max-width: 100%; height: 400px; max-height: 500px;"></div>
+                <div id="{{ids[2]}}" class="card mx-auto" style="width: 100%; max-width: 100%; height: 400px; max-height: 500px;"></div>
             </div>
             {% endif %}
-            
-            <p class="text-xs text-gray-500 text-center mt-4 italic">
-                Blue = Baseline. Orange = Optimized. Notice the precision vs recall trade-off.
-            </p>
+
+            <p class="caption mt-4 italic">Blue = Baseline. Orange = Optimized. Notice the precision vs recall trade-off.</p>
         </div>
     </section>
 {% endblock %}
@@ -139,5 +134,16 @@
             console.error('Error parsing or plotting graph JSON:', error);
         }
     });
+</script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.querySelector('#classifier form');
+  if (!form) return;
+  const submit = form.querySelector('button[type="submit"]');
+  form.addEventListener('submit', function () {
+    submit.disabled = true;
+    submit.innerHTML = 'Classifying… <span class="ml-2 animate-spin">⏳</span>';
+  });
+});
 </script>
 {% endblock %}

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -11,45 +11,46 @@
                     <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
                 </svg>
             </div>
-            <h1 class="text-4xl md:text-5xl font-extrabold text-white">
-                Analysis Complete
-            </h1>
+            <h1>Analysis Complete</h1>
         </div>
-        <p class="text-lg text-gray-400 max-w-3xl mx-auto">
-            Here's what the AI model detected in your message.
-        </p>
+        <p class="max-w-3xl mx-auto">Here's what the AI model detected in your message.</p>
     </div>
 
-    <!-- Results container -->
-    <div class="max-w-4xl mx-auto bg-brand-slate p-8 rounded-lg shadow-2xl mb-8">
-        <!-- Display the original query -->
-        <div class="mb-6">
-            <h4 class="text-lg font-semibold text-gray-400 uppercase tracking-wider mb-2">Message</h4>
-            <p class="text-xl text-white bg-gray-700 p-4 rounded-md">"{{query}}"</p>
-        </div>
+    <div class="card max-w-4xl mx-auto mb-8">
+        <h2 class="mb-2">Your Input</h2>
+        <p class="text-xl">"{{query}}"</p>
+    </div>
 
+    <div class="card max-w-4xl mx-auto mb-8">
         <!-- Display the classification results -->
         <div>
-            <h4 class="text-lg font-semibold text-gray-400 uppercase tracking-wider mb-3">Predicted Categories</h4>
+            <h2 class="mb-3">Predicted Categories</h2>
             <div class="flex flex-wrap gap-3">
                 {% set has_categories = false %}
                 {% for category, value in classification_result.items() %}
                     {% if value == 1 %}
                         {% set has_categories = true %}
-                        <span class="bg-brand-accent-amber text-gray-900 text-sm font-bold px-4 py-2 rounded-full shadow-md" title="Confidence: {{ (probabilities.get(category, 0) * 100)|round(1) }}%">
+                        <span class="badge-accent" title="Confidence: {{ (probabilities.get(category, 0) * 100)|round(1) }}%">
                             {{ category.replace('_', ' ')|title }} ({{ (probabilities.get(category, 0) * 100)|round(0) }}%)
                         </span>
                     {% endif %}
                 {% endfor %}
                 {% if not has_categories %}
-                    <p class="text-gray-400">This message does not appear to be related to a disaster.</p>
+                    <p class="text-[var(--muted)]">This message does not appear to be related to a disaster.</p>
                 {% endif %}
             </div>
+            <ul class="mt-4 text-[var(--muted)]">
+                {% for category, value in classification_result.items() %}
+                    {% if value == 0 %}
+                        <li>{{ category.replace('_', ' ')|title }}</li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
         </div>
 
         {% if top_category %}
         <div class="mt-6">
-            <p class="text-gray-300">
+            <p>
                 Most confident prediction:
                 <span class="font-bold text-brand-accent-amber">{{ top_category.replace('_', ' ')|title }}</span>
                 ({{ (top_confidence * 100)|round(1) }}% confidence)
@@ -59,18 +60,16 @@
 
         {% if probabilities %}
         <div class="mt-10">
-            <h4 class="text-lg font-semibold text-gray-400 uppercase tracking-wider mb-3">Confidence by Category</h4>
-            <div id="confidence-chart" class="bg-brand-charcoal p-4 rounded-lg shadow-lg" style="width: 100%; height: 400px;"></div>
-            <p class="text-sm text-gray-400 text-center mt-2">Higher bars indicate model confidence for each category.</p>
+            <h2 class="mb-3">Confidence by Category</h2>
+            <div id="confidence-chart" class="card" style="width: 100%; height: 400px;"></div>
+            <p class="caption text-center mt-2">Higher bars indicate model confidence for each category.</p>
         </div>
         {% endif %}
     </div>
 
     <!-- Call to action -->
     <div class="text-center mt-4 mb-8">
-        <a href="/" class="bg-brand-accent-blue hover:bg-blue-600 text-white font-bold py-3 px-6 rounded-md transition duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-brand-slate focus:ring-brand-accent-blue">
-            Classify Another Message
-        </a>
+        <a href="/" class="btn-primary">Classify Another Message</a>
     </div>
 
 {% endblock %}
@@ -88,15 +87,15 @@
             x: categories,
             y: values,
             type: 'bar',
-            marker: {color: '#FBBF24'}
+            marker: {color: '#3182CE'}
         }];
         const layout = {
-            yaxis: {title: 'Confidence (%)', range: [0, 100]},
-            xaxis: {automargin: true},
+            yaxis: {title: 'Confidence (%)', range: [0, 100], gridcolor: '#4A5568', color: 'rgb(156,163,175)'},
+            xaxis: {automargin: true, gridcolor: '#4A5568', color: 'rgb(156,163,175)'},
             margin: {t: 30},
-            paper_bgcolor: '#111827',
-            plot_bgcolor: '#111827',
-            font: {color: '#E5E7EB'}
+            paper_bgcolor: 'rgba(0,0,0,0)',
+            plot_bgcolor: 'rgba(0,0,0,0)',
+            font: {color: 'rgb(229,231,235)'}
         };
         Plotly.newPlot('confidence-chart', data, layout, {responsive: true, displaylogo: false});
     });

--- a/app/visualizations.py
+++ b/app/visualizations.py
@@ -13,12 +13,13 @@ logger = logging.getLogger(__name__)
 def _create_base_layout(title: str, xaxis_title: str, yaxis_title: str) -> go.Layout:
     """Creates a base layout for Plotly charts with a dark theme."""
     return go.Layout(
-        title={'text': title, 'font': {'color': '#E2E8F0'}},
-        xaxis={'title': xaxis_title, 'gridcolor': '#2D3748', 'color': '#A0AEC0'},
-        yaxis={'title': yaxis_title, 'gridcolor': '#2D3748', 'color': '#A0AEC0'},
-        paper_bgcolor='#1A202C',
-        plot_bgcolor='#1A202C',
-        legend={'font': {'color': '#E2E8F0'}},
+        title={'text': title},
+        xaxis={'title': xaxis_title, 'gridcolor': '#4A5568', 'color': 'rgb(156,163,175)'},
+        yaxis={'title': yaxis_title, 'gridcolor': '#4A5568', 'color': 'rgb(156,163,175)'},
+        paper_bgcolor='rgba(0,0,0,0)',
+        plot_bgcolor='rgba(0,0,0,0)',
+        font={'color': 'rgb(229,231,235)'},
+        legend={'font': {'color': 'rgb(229,231,235)'}},
         margin={'l': 80, 'r': 50, 't': 80, 'b': 50}
     )
 
@@ -38,10 +39,10 @@ class ChartGenerator:
     """Service for generating visualization charts."""
     
     COLOR_PALETTE = {
-        'primary': '#06d6a0',
-        'secondary': '#118ab2',
-        'tertiary': '#ffd166',
-        'quaternary': '#ef476f',
+        'primary': '#3182CE',
+        'secondary': '#4A5568',
+        'tertiary': '#718096',
+        'quaternary': '#A0AEC0',
         'neutral': '#A0AEC0'
     }
     


### PR DESCRIPTION
## Summary
- establish CSS variables, base defaults, and utility components for consistent dark theme
- make navigation sticky with cross-page anchors and add hero CTA, chart captions, and loading feedback
- present classification results with input recap, accent badges, and dark Plotly styling

## Testing
- `pytest` *(fails: Application configuration missing and Google Drive download errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f4b952508331add10a5593cc28ec